### PR TITLE
Initial work on controller metrics.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,30 @@
 
 
 [[projects]]
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "37c8de3658fcb183f997c4e13e8337516ab753e6"
+  version = "v1.0.1"
+
+[[projects]]
+  digest = "1:573ca21d3669500ff845bdebee890eb7fc7f0f50c59f2132f2a0c6b03d85086a"
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  pruneopts = "UT"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
+
+[[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:3f69624cb4ae8ab815a672f7d169d64786ee027a9d42eefab3c9d4e9debe0750"
   name = "github.com/openfaas/faas"
   packages = ["gateway/requests"]
@@ -25,6 +49,57 @@
   revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
   version = "v0.8.1"
 
+[[projects]]
+  digest = "1:eb04f69c8991e52eff33c428bd729e04208bf03235be88e4df0d88497c6861b9"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "170205fb58decfd011f1550d4cfb737230d7ae4f"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016"
+
+[[projects]]
+  digest = "1:8dcedf2e8f06c7f94e48267dea0bc0be261fa97b377f3ae3e87843a92a549481"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "31bed53e4047fd6c510e43a941f90cb31be0972a"
+  version = "v0.6.0"
+
+[[projects]]
+  digest = "1:366f5aa02ff6c1e2eccce9ca03a22a6d983da89eecff8a89965401764534eb7c"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/fs",
+  ]
+  pruneopts = "UT"
+  revision = "3f98efb27840a48a7a2898ec80be07674d19f9c8"
+  version = "v0.0.3"
+
+[[projects]]
+  branch = "master"
+  digest = "1:29fbe59f1e81b410505b4406f5bbc6f46c2c94d361992325db2d68dce51f1ca7"
+  name = "golang.org/x/sys"
+  packages = ["windows"]
+  pruneopts = "UT"
+  revision = "fde4db37ae7ad8191b03d30d27f258b5291ae4e3"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
@@ -32,6 +107,8 @@
     "github.com/openfaas/faas-provider/auth",
     "github.com/openfaas/faas/gateway/requests",
     "github.com/pkg/errors",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/types/metrics.go
+++ b/types/metrics.go
@@ -1,0 +1,74 @@
+package types
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	functionNameLabel = "function_name"
+)
+
+type MetricsCollector interface {
+	RegisterFunctionInvocation(fn string)
+	RegisterTopicMapSync()
+	Serve(bindAddr string) error
+}
+
+type defaultMetricsCollector struct {
+	lastFunctionInvocationTimestamp *prometheus.GaugeVec
+	lastTopicMapSyncTimestamp       prometheus.Gauge
+	registry                        *prometheus.Registry
+	totalFunctionInvocations        *prometheus.CounterVec
+	totalTopicMapSyncs              prometheus.Counter
+}
+
+func newDefaultMetricsCollector() *defaultMetricsCollector {
+	cm := &defaultMetricsCollector{
+		lastFunctionInvocationTimestamp: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "The timestamp at which a function has last been invoked.",
+			Name:      "last_function_invocation_timestamp",
+			Namespace: "controller",
+		}, []string{functionNameLabel}),
+		lastTopicMapSyncTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
+			Help:      "The timestamp at which the topic map has last been synced.",
+			Name:      "last_topic_map_sync_timestamp",
+			Namespace: "controller",
+		}),
+		registry: prometheus.NewRegistry(),
+		totalFunctionInvocations: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Help:      "The number of times a function has last been invoked.",
+			Name:      "total_function_invocations",
+			Namespace: "controller",
+		}, []string{functionNameLabel}),
+		totalTopicMapSyncs: prometheus.NewCounter(prometheus.CounterOpts{
+			Help:      "The number of times the topic map has been synced.",
+			Name:      "total_topic_map_syncs",
+			Namespace: "controller",
+		}),
+	}
+	cm.registry.MustRegister(cm.lastFunctionInvocationTimestamp)
+	cm.registry.MustRegister(cm.lastTopicMapSyncTimestamp)
+	cm.registry.MustRegister(cm.totalFunctionInvocations)
+	cm.registry.MustRegister(cm.totalTopicMapSyncs)
+	return cm
+}
+
+func (cm *defaultMetricsCollector) RegisterFunctionInvocation(fn string) {
+	cm.lastFunctionInvocationTimestamp.WithLabelValues(fn).SetToCurrentTime()
+	cm.totalFunctionInvocations.WithLabelValues(fn).Inc()
+}
+
+func (cm *defaultMetricsCollector) RegisterTopicMapSync() {
+	cm.lastTopicMapSyncTimestamp.SetToCurrentTime()
+	cm.totalTopicMapSyncs.Inc()
+}
+
+func (cm *defaultMetricsCollector) Serve(bindAddr string) error {
+	m := http.NewServeMux()
+	m.Handle("/metrics", promhttp.HandlerFor(cm.registry, promhttp.HandlerOpts{}))
+	s := http.Server{Addr: bindAddr, Handler: m}
+	return s.ListenAndServe()
+}


### PR DESCRIPTION
This PR represents an initial attempt at adding support for exposing controller metrics as a means of inspecting the behaviour of the connector. This approach was suggested by @alexellis in https://github.com/openfaas-incubator/connector-sdk/pull/27#issuecomment-519956481 as an alternative to a switch to control the verbosity of logging.

Closes #27.