### PR TITLE
controller: add content type option to send in the headers when invoking a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ Set the following in `ControllerConfig`:
 	}
 ```
 
+If you need to use the `Content-Type` header to validate or to check when it invoke the function you can set the `Content-Type`
+in `ControllerConfig`:
+
+```go
+	config := &types.ControllerConfig{
+        ...
+		ContentType: "application/json",
+	}
+```
+
 View the code: [cmd/tester/main.go](cmd/tester/main.go)
 
 ## License

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -33,6 +33,7 @@ func main() {
 		PrintResponse:           true,
 		PrintResponseBody:       true,
 		AsyncFunctionInvocation: false,
+		ContentType:             "text/plain",
 	}
 
 	controller := types.NewController(creds, config)

--- a/types/controller.go
+++ b/types/controller.go
@@ -38,6 +38,10 @@ type ControllerConfig struct {
 
 	// PrintSync indicates whether the sync should be logged.
 	PrintSync bool
+
+	// ContentType defines which content type will be set in the header to inkoke the function. i.e "application/json".
+	// Optional, if not set the Content-Type header will not be set.
+	ContentType string
 }
 
 // Controller is used to invoke functions on a per-topic basis and to subscribe to responses returned by said functions.
@@ -79,6 +83,7 @@ func NewController(credentials *auth.BasicAuthCredentials, config *ControllerCon
 
 	invoker := NewInvoker(gatewayFunctionPath,
 		MakeClient(config.UpstreamTimeout),
+		config.ContentType,
 		config.PrintResponse)
 
 	subs := []ResponseSubscriber{}

--- a/types/invoker.go
+++ b/types/invoker.go
@@ -21,6 +21,7 @@ type Invoker struct {
 	PrintResponse bool
 	Client        *http.Client
 	GatewayURL    string
+	ContentType   string
 	Responses     chan InvokerResponse
 }
 
@@ -37,11 +38,12 @@ type InvokerResponse struct {
 }
 
 // NewInvoker constructs an Invoker instance
-func NewInvoker(gatewayURL string, client *http.Client, printResponse bool) *Invoker {
+func NewInvoker(gatewayURL string, client *http.Client, contentType string, printResponse bool) *Invoker {
 	return &Invoker{
 		PrintResponse: printResponse,
 		Client:        client,
 		GatewayURL:    gatewayURL,
+		ContentType:   contentType,
 		Responses:     make(chan InvokerResponse),
 	}
 }
@@ -67,7 +69,7 @@ func (i *Invoker) InvokeWithContext(ctx context.Context, topicMap *TopicMap, top
 		gwURL := fmt.Sprintf("%s/%s", i.GatewayURL, matchedFunction)
 		reader := bytes.NewReader(*message)
 
-		body, statusCode, header, doErr := invokefunction(ctx, i.Client, gwURL, reader)
+		body, statusCode, header, doErr := invokefunction(ctx, i.Client, gwURL, i.ContentType, reader)
 
 		if doErr != nil {
 			i.Responses <- InvokerResponse{
@@ -88,7 +90,7 @@ func (i *Invoker) InvokeWithContext(ctx context.Context, topicMap *TopicMap, top
 	}
 }
 
-func invokefunction(ctx context.Context, c *http.Client, gwURL string, reader io.Reader) (*[]byte, int, *http.Header, error) {
+func invokefunction(ctx context.Context, c *http.Client, gwURL, contentType string, reader io.Reader) (*[]byte, int, *http.Header, error) {
 
 	httpReq, err := http.NewRequest(http.MethodPost, gwURL, reader)
 	if err != nil {
@@ -98,6 +100,10 @@ func invokefunction(ctx context.Context, c *http.Client, gwURL string, reader io
 
 	if httpReq.Body != nil {
 		defer httpReq.Body.Close()
+	}
+
+	if contentType != "" {
+		httpReq.Header.Set("Content-Type", contentType)
 	}
 
 	var body *[]byte


### PR DESCRIPTION
## Description
add content-type option to send in the headers when invoking a function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) - https://github.com/openfaas/connector-sdk/issues/58
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
To test this you will need to do:
- create a kind cluster: `kind create cluster`
- deploy openfaas with arkade: `arkade install openfaas --gateways 1 --load-balancer false`
- deploy a simple function that read and log the content-type header, like:

```go
package function

import (
	"fmt"
	"log"
	"os"
)

// Handle a serverless request
func Handle(req []byte) string {
        log.Printf("Content Type: %s", os.Getenv("Http_Content_Type"))
	return fmt.Sprintf("Hello! your Content-Type is: %s", os.Getenv("Http_Content_Type"))
}
```
and in the stack.yaml definition add the annotation

```yaml
annotations:
   topic: "vm.powered.on"
```

- Use the sample connector code from https://github.com/openfaas/connector-sdk/tree/master/cmd/tester
- Run it and will see the Content-type is empty
- use that changes in this PR and update the `tester` code to add `ContentType: "application/json",` the following line in the `&types.ControllerConfig` (https://github.com/openfaas/connector-sdk/blob/master/cmd/tester/main.go#L30-L36)

```
	config := &types.ControllerConfig{
		RebuildInterval:         time.Millisecond * 1000,
		GatewayURL:              "http://127.0.0.1:8080",
		PrintResponse:           true,
		PrintResponseBody:       true,
		AsyncFunctionInvocation: false,
		ContentType:             "application/json",
	}
```
- run it again and you will see the content-type being set
``` 
2021/06/12 17:21:19 Invoking on topic vm.powered.on - http://127.0.0.1:8080
2021/06/12 17:21:19 connector-sdk got result: [200] vm.powered.on => test.openfaas-fn (46) bytes
[200] vm.powered.on => test.openfaas-fn
Hello! your Content-Type is: application/json
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


Fixes: https://github.com/openfaas/connector-sdk/issues/58